### PR TITLE
set relative image url for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Timestamp Fix_x Fix_y
 3576 380 433
 ```
 ## Screenshots
-[[https://github.com/theskinnerbox/ASTEF/blob/master/ASTEF-load.png]]
+
+![Screenshot](ASTEF-load.png)
 
 ## Available programming languages
 


### PR DESCRIPTION
Hi guys, my name is Francesco. Claudio asked me for some help with the web application for the project.

In the meantime, I noticed that the README.md screenshot was not displayed as expected:

![screen-astef](https://cloud.githubusercontent.com/assets/1940952/13722657/819825f8-e84d-11e5-8f6d-b6121a8f8387.png)

So I have fixed it. Hope it helps :)
Cheers
